### PR TITLE
Fix typo in error message for GraphQLAbsoluteUrl

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -60,7 +60,7 @@ export const GraphQLAbsoluteUrl = new GraphQLScalarType({
   parseValue: validateAbsoluteUrl,
   parseLiteral(ast) {
     assertErr(ast.kind === Kind.STRING,
-      GraphQLError, `Query error: Can only parse strings to AbsvalidateAbsoluteUrls but got a: ${ast.kind}`, [ast]);
+      GraphQLError, `Query error: Can only parse strings to urls but got a: ${ast.kind}`, [ast]);
 
     assertErr(isAbsoluteUrl(ast.value), GraphQLError, 'Query error: Invalid url', [ast]);
 


### PR DESCRIPTION
This brings the error message in line with the others.