### PR TITLE
Add type description texts

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -28,6 +28,7 @@ const validateAbsoluteUrl = (url) => {
 
 export const GraphQLUrl = new GraphQLScalarType({
   name: 'Url',
+  description: 'A valid absolute (starting with either a valid protocol or a leading www) or relative (with a leading slash) URL string',
   serialize: validateUrl,
   parseValue: validateUrl,
   parseLiteral(ast) {
@@ -42,6 +43,7 @@ export const GraphQLUrl = new GraphQLScalarType({
 
 export const GraphQLRelativeUrl = new GraphQLScalarType({
   name: 'RelativeUrl',
+  description: 'A valid relative URL string with a leading slash (/)',
   serialize: validateRelativeUrl,
   parseValue: validateRelativeUrl,
   parseLiteral(ast) {
@@ -56,6 +58,7 @@ export const GraphQLRelativeUrl = new GraphQLScalarType({
 
 export const GraphQLAbsoluteUrl = new GraphQLScalarType({
   name: 'AbsoluteUrl',
+  description: 'A valid absolute URL string starting with either a valid protocol or a leading www',
   serialize: validateAbsoluteUrl,
   parseValue: validateAbsoluteUrl,
   parseLiteral(ast) {


### PR DESCRIPTION
Added descriptions to all three exposed types to have all that stuff documented within the schema. 

Custom scalars should probably usually have these, otherwise the validation that's being done under the hood remains a mystery if you don't peek under the hood.

![](https://media.giphy.com/media/bn0zlGb4LOyo8/giphy.gif)